### PR TITLE
Allow attributes with boolean or enum properties.

### DIFF
--- a/src/RequestHandlers.Mvc.Tests/CSharp/AttributeGeneratorTests.cs
+++ b/src/RequestHandlers.Mvc.Tests/CSharp/AttributeGeneratorTests.cs
@@ -32,13 +32,13 @@ namespace RequestHandlers.Mvc.Tests.CSharp
             Assert.Equal("[RequestHandlers.Mvc.Tests.CSharp.TestNamedArgumentsAttribute(StringProperty = \"Yenthe\")]", stringAttribute);
         }
 
-        [TestNamedArguments(StringProperty = "Yenthe", IntProperty = 5)] class AttributeWithNamedArgumentsHost { }
+        [TestNamedArguments(StringProperty = "Yenthe", IntProperty = 5, BoolProperty = true)] class AttributeWithNamedArgumentsHost { }
 
         [Fact]
         public void Generate_GivenCustomAttributeData_WithMultipleNamedArguments_GenerateAttributeAsString()
         {
             var stringAttribute = _sut.Generate(typeof(AttributeWithNamedArgumentsHost).GetCustomAttributesData().First());
-            Assert.Equal("[RequestHandlers.Mvc.Tests.CSharp.TestNamedArgumentsAttribute(StringProperty = \"Yenthe\", IntProperty = 5)]", stringAttribute);
+            Assert.Equal("[RequestHandlers.Mvc.Tests.CSharp.TestNamedArgumentsAttribute(StringProperty = \"Yenthe\", IntProperty = 5, BoolProperty = true)]", stringAttribute);
         }
 
         [TestNamedArguments(EnumProperty = TestEnum.SecondValue)] class AttributeWithEnumNamedArgumentHost { }
@@ -47,7 +47,7 @@ namespace RequestHandlers.Mvc.Tests.CSharp
         public void Generate_GivenCustomAttributeData_WithEnumNamedArgument_GenerateAttributeAsString()
         {
             var stringAttribute = _sut.Generate(typeof(AttributeWithEnumNamedArgumentHost).GetCustomAttributesData().First());
-            Assert.Equal("[RequestHandlers.Mvc.Tests.CSharp.TestNamedArgumentsAttribute(EnumProperty = 1)]", stringAttribute);
+            Assert.Equal("[RequestHandlers.Mvc.Tests.CSharp.TestNamedArgumentsAttribute(EnumProperty = RequestHandlers.Mvc.Tests.CSharp.TestEnum.SecondValue)]", stringAttribute);
         }
 
         [TestConstructorArguments("first", 2, TestEnum.ThirdValue)] class AttributeWithConstructorArgumentsHost { }
@@ -56,7 +56,7 @@ namespace RequestHandlers.Mvc.Tests.CSharp
         public void Generate_GivenCustomAttributeData_WithConstructorArguments_GenerateAttributeAsString()
         {
             var stringAttribute = _sut.Generate(typeof(AttributeWithConstructorArgumentsHost).GetCustomAttributesData().First());
-            Assert.Equal("[RequestHandlers.Mvc.Tests.CSharp.TestConstructorArgumentsAttribute(\"first\", 2, 2)]", stringAttribute);
+            Assert.Equal("[RequestHandlers.Mvc.Tests.CSharp.TestConstructorArgumentsAttribute(\"first\", 2, RequestHandlers.Mvc.Tests.CSharp.TestEnum.ThirdValue)]", stringAttribute);
         }
 
         [TestConstructorArguments("first", 2, TestEnum.ThirdValue, Property = "Yenthe")] class AttributeWithNamedAndConstructorArgumentsHost { }
@@ -65,7 +65,7 @@ namespace RequestHandlers.Mvc.Tests.CSharp
         public void Generate_GivenCustomAttributeData_WithNamedAndConstructorArguments_GenerateAttributeAsString()
         {
             var stringAttribute = _sut.Generate(typeof(AttributeWithNamedAndConstructorArgumentsHost).GetCustomAttributesData().First());
-            Assert.Equal("[RequestHandlers.Mvc.Tests.CSharp.TestConstructorArgumentsAttribute(\"first\", 2, 2, Property = \"Yenthe\")]", stringAttribute);
+            Assert.Equal("[RequestHandlers.Mvc.Tests.CSharp.TestConstructorArgumentsAttribute(\"first\", 2, RequestHandlers.Mvc.Tests.CSharp.TestEnum.ThirdValue, Property = \"Yenthe\")]", stringAttribute);
         }
     }
 
@@ -81,6 +81,7 @@ namespace RequestHandlers.Mvc.Tests.CSharp
         public string StringProperty { get; set; }
         public int IntProperty { get; set; }
         public TestEnum EnumProperty { get; set; }
+        public bool BoolProperty { get; set; }
     }
 
     public class TestConstructorArgumentsAttribute : Attribute

--- a/src/RequestHandlers.Mvc/CSharp/AttributeGenerator.cs
+++ b/src/RequestHandlers.Mvc/CSharp/AttributeGenerator.cs
@@ -33,17 +33,32 @@ namespace RequestHandlers.Mvc.CSharp
 
         private string GenerateConstructorArgument(CustomAttributeTypedArgument constructorArgument)
         {
-            return ObjectToCodeString(constructorArgument.Value);
+            return ObjectToCodeString(constructorArgument.ArgumentType, constructorArgument.Value);
         }
 
         private string GenerateNamedArgument(CustomAttributeNamedArgument namedArgument)
         {
-            return $"{namedArgument.MemberName} = {ObjectToCodeString(namedArgument.TypedValue.Value)}";
+            return $"{namedArgument.MemberName} = {ObjectToCodeString(namedArgument.TypedValue.ArgumentType, namedArgument.TypedValue.Value)}";
         }
 
-        private static string ObjectToCodeString(object value)
+        private static string ObjectToCodeString(Type type, object value)
         {
-            return value is string ? $"\"{value}\"" : value.ToString();
+            if (type == typeof(string))
+            {
+                return $"\"{value}\"";
+            }
+
+            if (type == typeof(bool))
+            {
+                return (bool)value ? "true" : "false";
+            }
+
+            if (type.GetTypeInfo().IsEnum)
+            {
+                return type.FullName + "." + Enum.GetName(type, value);
+            }
+
+            return value.ToString();
         }
     }
 }


### PR DESCRIPTION
Booleans would result in `True` or `False` which isn't valid (should be lowercase)
Enums should be defined as the enum name, converting from the number can give errors. 
(Problem found with ResponseCacheAttribute)