### PR TITLE
Fixed issues when saving compilation to file

### DIFF
--- a/src/RequestHandlers.Mvc/CSharp/CSharpBuilder.cs
+++ b/src/RequestHandlers.Mvc/CSharp/CSharpBuilder.cs
@@ -88,8 +88,15 @@ namespace RequestHandlers.Mvc.CSharp
                 }
                 throw new Exception(errormsg.ToString());
             }
-            assemblyStream.Seek(0, SeekOrigin.Begin);
-            return AssemblyLoadContext.Default.LoadFromStream(assemblyStream);
+            if (saveToFile)
+            {
+                return AssemblyLoadContext.Default.LoadFromAssemblyPath(_saveToFilePath);
+            }
+            else
+            {
+                assemblyStream.Seek(0, SeekOrigin.Begin);
+                return AssemblyLoadContext.Default.LoadFromStream(assemblyStream);
+            }
         }
 
         private string GetOperationName(Type requestType)


### PR DESCRIPTION
I noticed that when a compilation gets saved to a file location, the memory stream is still used to load the assembly. The memory stream will be empty so that will create `System.BadImageFormatException: Bad IL format`.